### PR TITLE
fix: genre translated in other languages to only english

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -117,7 +117,7 @@ function getArtistsURI(): string | null {
 
 async function fetchGenres(artistURI: string): Promise<string[]> {
 	const res: SpotifyApi.SingleArtistResponse = await Spicetify.CosmosAsync.get(
-		`https://api.spotify.com/v1/artists/${artistURI}`
+		`https://api.spotify.com/v1/artists/${artistURI}?locale=EN_en`
 	);
 	return res.genres;
 }


### PR DESCRIPTION
**Issue**: The code retrieve the genres with the user local language, so it will not work for people that have their application in a different language than english

**Solution**: I just added the parameter `locale=EN_en` when fetching the artist genres

Related issue:

#6 